### PR TITLE
Feat/content view img pdf #39

### DIFF
--- a/src/components/ViewContent.js
+++ b/src/components/ViewContent.js
@@ -9,7 +9,7 @@ function ViewContent() {
     contentDataType: '',
     contentName: '',
     contentLink: '',
-    contentImage: '',
+    contentImage: [],
     contentDoc: '',
     thumbnailImage: '',
     boardCategory: [],
@@ -41,9 +41,8 @@ function ViewContent() {
       headers: { Authorization: `${token}` },
     });
     try {
-      const response = await api.get(
-        `/api/v1/content/all/${contentInfo.contentId}`,
-      );
+      const contentId = 14;
+      const response = await api.get(`/api/v1/content/all/${contentId}`);
       const results = response.data.results[0];
       console.log('결과', results);
       setContentInfo({
@@ -94,21 +93,52 @@ function ViewContent() {
             ))}
           </ContentDiv>
           <ContentDiv>
-            <Name>링크</Name>
-            <Link onClick={() => handleLinkClick(`${contentInfo.contentLink}`)}>
-              <Icon
-                icon="ic:twotone-link"
-                width="24"
-                height="24"
-                style={{
-                  color: '#4f4f4f',
-                  marginRight: '10px',
-                  paddingBottom: '3px',
-                  verticalAlign: 'middle',
-                }}
-              />
-              {contentInfo.contentLink}
-            </Link>
+            <Name>
+              {contentInfo.contentDataType === 'LINK'
+                ? '링크'
+                : contentInfo.contentDataType === 'IMAGE'
+                  ? '이미지'
+                  : 'PDF 파일'}
+            </Name>
+
+            {contentInfo.contentDataType === 'LINK' && (
+              <Link
+                onClick={() => handleLinkClick(`${contentInfo.contentLink}`)}
+              >
+                <Icon
+                  icon="ic:twotone-link"
+                  width="24"
+                  height="24"
+                  style={{
+                    color: '#4f4f4f',
+                    marginRight: '10px',
+                    paddingBottom: '3px',
+                    verticalAlign: 'middle',
+                  }}
+                />
+                {contentInfo.contentLink}
+              </Link>
+            )}
+            {contentInfo.contentDataType === 'IMAGE' && (
+              <ImagesWrapper>
+                {contentInfo.contentImage.map((image, index) => (
+                  <ImageContainer key={image}>
+                    {/* <ImageBox onClick={() => handleSetRepresentative(index)}> */}
+                    <ImageBox>
+                      {index === 0 && (
+                        <RepresentativeLabel>대표</RepresentativeLabel>
+                      )}
+                      <ImagePreview
+                        src={image}
+                        alt=""
+                        onClick={console.log(image)}
+                      />
+                    </ImageBox>
+                    {/* <FileName></FileName> */}
+                  </ImageContainer>
+                ))}
+              </ImagesWrapper>
+            )}
           </ContentDiv>
           <ContentDiv>
             <Name>태그 (2개 이상)*</Name>
@@ -337,5 +367,67 @@ const Button = styled.button`
   font-weight: 500;
   margin-bottom: 98px;
 `;
+
+// 이미지 조회 컴포넌트
+
+const ImagesWrapper = styled.div`
+  display: flex;
+  gap: 30px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 1100px;
+`;
+
+const ImageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ImageBox = styled.div`
+  width: 159px;
+  height: 177px;
+  position: relative;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const RepresentativeLabel = styled.div`
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  background-color: #47c28b;
+  color: white;
+  padding: 2px 6px;
+  font-size: 12px;
+  border-radius: 12px;
+`;
+
+const ImagePreview = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  object-fit: cover;
+`;
+
+// const FileName = styled.div`
+//   margin-top: 8px;
+//   font-size: 14px;
+//   color: #666;
+//   text-align: center;
+//   width: 140px; // 사진 크기에 맞게 조정
+//   max-width: 100%;
+//   overflow: hidden;
+//   text-overflow: ellipsis;
+//   white-space: nowrap;
+// `;
 
 export default ViewContent;

--- a/src/components/ViewContent.js
+++ b/src/components/ViewContent.js
@@ -41,7 +41,7 @@ function ViewContent() {
       headers: { Authorization: `${token}` },
     });
     try {
-      const contentId = 1;
+      const contentId = 13;
       const response = await api.get(`/api/v1/content/all/${contentId}`);
       const results = response.data.results[0];
       console.log('결과', results);
@@ -107,9 +107,10 @@ function ViewContent() {
                   contentInfo.contentDataType === 'PDF' ||
                   contentInfo.contentDataType === 'IMAGE'
                     ? 'flex-start'
-                    : 'center', // 이미지와 PDF 외에는 중앙 정렬 유지
+                    : 'center',
               }}
             >
+              {/* 이미지, pdf 조회 부분에서 스타일 조정이 필요해서 복잡한 코드.. 나중에 수정할 수 있음 하도록 */}
               {contentInfo.contentDataType === 'LINK'
                 ? '링크'
                 : contentInfo.contentDataType === 'IMAGE'

--- a/src/components/ViewContent.js
+++ b/src/components/ViewContent.js
@@ -41,7 +41,7 @@ function ViewContent() {
       headers: { Authorization: `${token}` },
     });
     try {
-      const contentId = 13;
+      const contentId = 1;
       const response = await api.get(`/api/v1/content/all/${contentId}`);
       const results = response.data.results[0];
       console.log('결과', results);
@@ -180,7 +180,7 @@ function ViewContent() {
             )}
           </ContentDiv>
           <ContentDiv>
-            <Name>태그 (2개 이상)*</Name>
+            <Name>태그</Name>
             {contentInfo.tags.map((tag) => (
               <CategoryTag key={tag}>{tag}</CategoryTag>
             ))}
@@ -386,7 +386,7 @@ const Long = styled.div`
 const Name = styled.div`
   font-weight: 400;
   font-size: 30px;
-  width: 238px;
+  width: 154px;
   padding-top: 5px;
   &.dday {
     width: 550px;

--- a/src/components/ViewContent.js
+++ b/src/components/ViewContent.js
@@ -41,7 +41,7 @@ function ViewContent() {
       headers: { Authorization: `${token}` },
     });
     try {
-      const contentId = 14;
+      const contentId = 13;
       const response = await api.get(`/api/v1/content/all/${contentId}`);
       const results = response.data.results[0];
       console.log('결과', results);
@@ -138,6 +138,29 @@ function ViewContent() {
                   </ImageContainer>
                 ))}
               </ImagesWrapper>
+            )}
+            {contentInfo.contentDataType === 'PDF' && (
+              <FilesWrapper>
+                {contentInfo.contentDoc.map((file, index) => (
+                  <FileContainer key={file}>
+                    {/* <FileBox onClick={() => handleSetRepresentative(index)}> */}
+                    <FileBox onClick={() => window.open(file, '_blank')}>
+                      {index === 0 && (
+                        <RepresentativeLabel>대표</RepresentativeLabel>
+                      )}
+                      <FileIcon>
+                        <Icon
+                          icon="file-icons:pdf"
+                          width="40"
+                          height="40"
+                          style={{ color: '#4CAF50' }}
+                        />
+                      </FileIcon>
+                    </FileBox>
+                    {/* <FileName>파일이름</FileName> */}
+                  </FileContainer>
+                ))}
+              </FilesWrapper>
             )}
           </ContentDiv>
           <ContentDiv>
@@ -429,5 +452,44 @@ const ImagePreview = styled.img`
 //   text-overflow: ellipsis;
 //   white-space: nowrap;
 // `;
+
+// 링크 조회 관련 스타일
+
+const FilesWrapper = styled.div`
+  display: flex;
+  gap: 30px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 1100px;
+`;
+
+const FileContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const FileBox = styled.div`
+  width: 159px;
+  height: 177px;
+  position: relative;
+  background-color: #eaf4f4;
+  border-radius: 4px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const FileIcon = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #4caf50;
+`;
 
 export default ViewContent;

--- a/src/components/ViewContent.js
+++ b/src/components/ViewContent.js
@@ -92,8 +92,24 @@ function ViewContent() {
               <CategoryTag key={category}>{category}</CategoryTag>
             ))}
           </ContentDiv>
-          <ContentDiv>
-            <Name>
+          <ContentDiv
+            style={{
+              flexDirection:
+                contentInfo.contentDataType === 'PDF' ||
+                contentInfo.contentDataType === 'IMAGE'
+                  ? 'column'
+                  : 'row',
+            }}
+          >
+            <Name
+              style={{
+                alignSelf:
+                  contentInfo.contentDataType === 'PDF' ||
+                  contentInfo.contentDataType === 'IMAGE'
+                    ? 'flex-start'
+                    : 'center', // 이미지와 PDF 외에는 중앙 정렬 유지
+              }}
+            >
               {contentInfo.contentDataType === 'LINK'
                 ? '링크'
                 : contentInfo.contentDataType === 'IMAGE'
@@ -269,7 +285,7 @@ const TitleDiv = styled.p`
 
 const ContentDiv = styled.div`
   display: flex;
-  align-items: center;
+  /* align-items: center; */
 `;
 
 const CategoryTag = styled.div`
@@ -371,6 +387,7 @@ const Name = styled.div`
   font-weight: 400;
   font-size: 30px;
   width: 238px;
+  padding-top: 5px;
   &.dday {
     width: 550px;
   }
@@ -403,6 +420,7 @@ const ImagesWrapper = styled.div`
   border-radius: 8px;
   width: 100%;
   max-width: 1100px;
+  margin-top: 16px;
 `;
 
 const ImageContainer = styled.div`
@@ -465,6 +483,7 @@ const FilesWrapper = styled.div`
   border-radius: 8px;
   width: 100%;
   max-width: 1100px;
+  margin-top: 16px;
 `;
 
 const FileContainer = styled.div`


### PR DESCRIPTION
## Summary 🪺

<!-- 간단한 요약내용을 써주세요 -->
콘텐츠 상세 조회 링크, 이미지, PDF 구현 완료
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2faa74a2-d758-4da1-8768-dd81af69be4c">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/acfa61e8-b3d8-4d7b-b4f0-b83254f5030d">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b3482698-3bc5-4cb3-a6db-5ddb594218b9">

## Issue Number 🌱

<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

- #39

## To Reviewers 🙏

<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
1. 구현하다가 생각하게 된건데
<img width="660" alt="image" src="https://github.com/user-attachments/assets/1edb60bb-08fd-4434-98f3-e4a7558170a6">

이미지는 위의 정보 조회 모달이 필요하겠지만, pdf는 필요할까요?
일단 지금은 pdf 잘 되는지 보려고 클릭하면 다운받도록 해놨는데 굳이 저 모달이 뜨지 않아도 pdf클릭하면 바로 다운로드 되니까.. 
한번 생각해주시면 감사하겠습니다. 꼭 필요한 기능이 아니라면 빼는 것도 방법이니까요!

2. 파일 이름 띄우는 것은 아직 안 했습니다! 후에 하겠습니다.