### PR TITLE
잇타 6기 아둥이 프론트엔드 코드 리뷰용 PR

### DIFF
--- a/src/components/ContentHeader.js
+++ b/src/components/ContentHeader.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
-import filterEditIcon from '../assets/icons/filterEdit.png';
+import filterEditIcon from './../assets/icons/filterEdit.png';
 import { Icon } from '@iconify/react';
 import AddTagModal from './modal/AddTagModal';
 import TagFilterModal from '../components/modal/TagFilterModal';

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -2,7 +2,7 @@ import styled, { keyframes } from 'styled-components';
 import { useState, useEffect, useRef } from 'react';
 import seedIcon from '../assets/icons/seed_sidebar.png';
 import reminderIcon from '../assets/icons/reminder_sidebar.png';
-import circleCheckIcon from '../assets/icons/circleCheck.png';
+import circleCheckIcon from './../assets/icons/circleCheck.png';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -352,6 +352,10 @@ const Sidebar = ({
     setTimeout(() => setMessage(''), 2000);
   };
 
+  /******************************************************************************************/
+  // 맨처음 페이지 렌더링 이후 '/api/v1/filter'로 요청을 보내지만
+  // 다음과 같은 오류 발생, Custom 필터 조회 오류 발생: TypeError: Cannot read properties of undefined (reading 'map') at CustomFilterViews
+  // 한번 새로고침을 해야지만 필터 조회 성공
   const CustomFilterViews = async () => {
     try {
       const response = await axiosInstance.get('/api/v1/filter');
@@ -375,6 +379,7 @@ const Sidebar = ({
     handleViewCategory();
     CustomFilterViews();
   }, []);
+  /******************************************************************************************/
 
   return (
     <StMainPage>

--- a/src/components/modal/ContentDeleteModal.js
+++ b/src/components/modal/ContentDeleteModal.js
@@ -19,9 +19,7 @@ const ContentDeleteModal = forwardRef(({ contentId }, ref) => {
   const handleDelete = async () => {
     console.log('콘텐츠 삭제 id: ', contentId);
     try {
-      const response = await api.delete(
-        `/api/v1/content/api/v1/content/${contentId}`,
-      );
+      const response = await api.delete(`/api/v1/content/${contentId}`);
 
       console.log('삭제 성공: ', response?.data.results);
       cloesModal();

--- a/src/components/modal/ContentDeleteModal.js
+++ b/src/components/modal/ContentDeleteModal.js
@@ -10,7 +10,8 @@ const api = axios.create({
     Authorization: `${token}`, // 토큰을 템플릿 리터럴로 추가
   },
 });
-
+/******************************************************************************************/
+// 콘텐츠 삭제
 const ContentDeleteModal = forwardRef(({ contentId }, ref) => {
   const cloesModal = () => {
     ref.current?.close();
@@ -28,6 +29,7 @@ const ContentDeleteModal = forwardRef(({ contentId }, ref) => {
       throw error;
     }
   };
+  /******************************************************************************************/
 
   useEffect(() => {
     if (ref.current) {

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -40,6 +40,8 @@ const MainPage = () => {
 
   console.log('activeTab : ', activeTab);
 
+  /******************************************************************************************/
+  // fetchData : 메인페이지의 모든 콘텐츠들을 조회하는 api 요청 함수
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
@@ -122,6 +124,8 @@ const MainPage = () => {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+  // 문제 사례 : ContentDeleteModal.js에서 콘텐츠를 삭제했을 때, 새로고침을 하지 않으면 콘텐츠 삭제된 것이 반영되지 않음
+  /******************************************************************************************/
 
   // 정렬 처리
   useEffect(() => {


### PR DESCRIPTION
## To Reviewers 🙏

<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
```javascript
// 1. 렌더링 될 때 마다 실행
useEffect(()=>{
    console.log('렌더링 때마다 실행');
});
    
// 2. 처음 렌더링 되거나 배열 값이 바뀔때마다 실행
useEffect(()=>{
    console.log('name 변수가 바뀔 때마다 실행');
},[name]);
    
// 3. 처음 렌더링이 될 때만 실행
useEffect(()=>{
    console.log('처음 렌더링 때만 실행');
},[]);

```
useEffect는 컴포넌트가 렌더링될 때마다 의존성 배열에 따라 호출되는데,
콘텐츠 삭제 또는 사이드바 API 호출 시 1번과 같은 방법으로 매번 작업을 호출하기엔 리소스 낭비가 심합니다.
-> 리소스 낭비를 피하기 위해 특정 배열값이 바뀔 때마다 실행되도록 제한을 두면 문제가 해결되지 않습니다.

위의 방법 말고 다른 방법이 있을지 검토 부탁드립니다.